### PR TITLE
Ch host heroku

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -4,5 +4,6 @@ DB_USER=
 DB_PASSWORD=
 DB_HOST=
 FRONTEND_URL=https://example.com
+BACKEND_URL=landreg.com # this URL will be added to Allowed hosts.
 USERNAME= #username for africaIsTalking
 API_KEY = #api_key for africaIsTalking

--- a/landreg/settings.py
+++ b/landreg/settings.py
@@ -31,7 +31,9 @@ SECRET_KEY = os.getenv('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    os.getenv('BACKEND_URL'),
+]
 
 
 # Application definition
@@ -133,6 +135,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 AUTH_USER_MODEL = 'authentication.User'
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
#### What does this PR do?
- Configures application to run on heroku without Django-Heroku.

#### Description of tasks completed.
- Add STATIC_ROOT setting in settings.py.
- Add Heroku Domain to ALLOWED_HOSTS.